### PR TITLE
Fix: Unable to list the errors for Buildspecs 

### DIFF
--- a/src/act.core.web/Views/BuildSpec/ReviewDataPartial.cshtml
+++ b/src/act.core.web/Views/BuildSpec/ReviewDataPartial.cshtml
@@ -2,7 +2,7 @@
 @model act.core.web.Models.BuildSpec.ReviewData
 
 
-<table class="table table-striped" data-name="@Model.Name" data-success="@((Model.Count == 0 && Model.CountOfOsFailures == 0).ToString().ToLower())">
+<table class="table table-striped" data-name="@Model.Name" data-success="@((Model.Count == 0 && Model.CountOfOsFailures == 0 && Model.Errors.Count() == 0).ToString().ToLower())">
     <thead>
     <tr>
         <th>Result&nbsp;Type</th>


### PR DESCRIPTION
Fixed the logic to consider Compliance errors as well when calculating the feedback to jQuery to display the list of errors and issues.
BugzID: DD-94380